### PR TITLE
Decode log lines to Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Logfmt [![Build Status](https://travis-ci.org/jclem/logfmt-elixir.svg?branch=master)](https://travis-ci.org/jclem/logfmt-elixir)
 
-Decode log lines into keyword lists:
+Decode log lines into maps:
 
 ```elixir
 iex> Logfmt.decode "foo=bar"
-[foo: "bar"]
+%{"foo" => "bar"}
 ```
 
 Encode keyword lists into log lines:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,28 @@ iex> Logfmt.decode "foo=bar"
 %{"foo" => "bar"}
 ```
 
-Encode keyword lists into log lines:
+Encode Dict implementation values into log lines:
 
 ```elixir
 iex> Logfmt.encode [foo: "bar"]
 "foo=bar"
+
+iex> Logfmt.encode %{foo: "bar"}
+"foo=bar"
 ```
+
+## Why decode into maps?
+
+Originally, this library both decoded and encoded maps. However, this was
+problematic because key ordering in maps is not guaranteed. A developer wants to
+be able to ensure that their log output will have identical ordering for
+multiple calls for the sake of readability.
+
+To solve this, the second version encoded and decoded Keyword lists only. Of
+course, this is also problematic because decoding log lines into Keyword lists
+involves converting user strings into non-garbage-collected atoms.
+
+Now, this module decodes into maps only (with string keys) and encodes any Dict
+implementation type. This is a fair compromise, because ordering upon decoding a
+Logfmt line is not important, and keeping only the last value for a duplicate
+key in a log line is fair, as well.

--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -1,128 +1,128 @@
 defmodule Logfmt.Decoder do
   import String, only: [next_grapheme: 1]
 
-  @spec decode(String.t) :: Keyword.t
+  @spec decode(String.t) :: map
   def decode(string) do
-    parse_char(next_grapheme(string), :garbage, Keyword.new)
+    parse_char(next_grapheme(string), :garbage, Map.new)
   end
 
-  @spec parse_char({String.t, String.t}, :garbage, Keyword.t) :: Keyword.t
-  defp parse_char({char, rest}, :garbage, list)
+  @spec parse_char({String.t, String.t}, :garbage, map) :: map
+  defp parse_char({char, rest}, :garbage, map)
   when char > " " and char != "\"" and char != "=" do
-    parse_char(next_grapheme(rest), :key, char, list)
+    parse_char(next_grapheme(rest), :key, char, map)
   end
 
-  @spec parse_char({String.t, String.t}, :garbage, Keyword.t) :: Keyword.t
-  defp parse_char({_char, rest}, :garbage, list) do
-    parse_char(next_grapheme(rest), :garbage, list)
+  @spec parse_char({String.t, String.t}, :garbage, map) :: map
+  defp parse_char({_char, rest}, :garbage, map) do
+    parse_char(next_grapheme(rest), :garbage, map)
   end
 
-  @spec parse_char(nil, :garbage, Keyword.t) :: Keyword.t
-  defp parse_char(nil, :garbage, list) do
-    list
+  @spec parse_char(nil, :garbage, map) :: map
+  defp parse_char(nil, :garbage, map) do
+    map
   end
 
-  @spec parse_char({String.t, String.t}, :key, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({char, rest}, :key, key, list)
+  @spec parse_char({String.t, String.t}, :key, String.t, map) :: map
+  defp parse_char({char, rest}, :key, key, map)
   when char > " " and char != "\"" and char != "=" do
-    parse_char(next_grapheme(rest), :key, key <> char, list)
+    parse_char(next_grapheme(rest), :key, key <> char, map)
   end
 
-  @spec parse_char({String.t, String.t}, :key, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({"=", rest}, :key, key, list) do
-    parse_char(next_grapheme(rest), :equals, key, list)
+  @spec parse_char({String.t, String.t}, :key, String.t, map) :: map
+  defp parse_char({"=", rest}, :key, key, map) do
+    parse_char(next_grapheme(rest), :equals, key, map)
   end
 
-  @spec parse_char({String.t, String.t}, :key, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({_char, rest}, :key, key, list) do
-    parse_char(next_grapheme(rest), :garbage, list |> put_value(key, true))
+  @spec parse_char({String.t, String.t}, :key, String.t, map) :: map
+  defp parse_char({_char, rest}, :key, key, map) do
+    parse_char(next_grapheme(rest), :garbage, map |> put_value(key, true))
   end
 
-  @spec parse_char(nil, :key, String.t, Keyword.t) :: Keyword.t
-  defp parse_char(nil, :key, key, list) do
-    list |> put_value(key, true)
+  @spec parse_char(nil, :key, String.t, map) :: map
+  defp parse_char(nil, :key, key, map) do
+    map |> put_value(key, true)
   end
 
-  @spec parse_char({String.t, String.t}, :equals, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({char, rest}, :equals, key, list)
+  @spec parse_char({String.t, String.t}, :equals, String.t, map) :: map
+  defp parse_char({char, rest}, :equals, key, map)
   when char > " " and char != "\"" and char != "=" do
-    parse_char(next_grapheme(rest), :ivalue, key, char, list)
+    parse_char(next_grapheme(rest), :ivalue, key, char, map)
   end
 
-  @spec parse_char({String.t, String.t}, :equals, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({"\"", rest}, :equals, key, list) do
-    parse_char(next_grapheme(rest), :qvalue, false, key, "", list)
+  @spec parse_char({String.t, String.t}, :equals, String.t, map) :: map
+  defp parse_char({"\"", rest}, :equals, key, map) do
+    parse_char(next_grapheme(rest), :qvalue, false, key, "", map)
   end
 
-  @spec parse_char({String.t, String.t}, :equals, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({_char, rest}, :equals, key, list) do
-    parse_char(next_grapheme(rest), :garbage, list |> put_value(key, true))
+  @spec parse_char({String.t, String.t}, :equals, String.t, map) :: map
+  defp parse_char({_char, rest}, :equals, key, map) do
+    parse_char(next_grapheme(rest), :garbage, map |> put_value(key, true))
   end
 
-  @spec parse_char(nil, :equals, String.t, Keyword.t) :: Keyword.t
-  defp parse_char(nil, :equals, key, list) do
-    list |> put_value(key, true)
+  @spec parse_char(nil, :equals, String.t, map) :: map
+  defp parse_char(nil, :equals, key, map) do
+    map |> put_value(key, true)
   end
 
-  @spec parse_char({String.t, String.t}, :ivalue, String.t, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({char, rest}, :ivalue, key, value, list)
+  @spec parse_char({String.t, String.t}, :ivalue, String.t, String.t, map) :: map
+  defp parse_char({char, rest}, :ivalue, key, value, map)
   when char <= " " or char == "\"" or char == "=" do
-    parse_char(next_grapheme(rest), :garbage, list |> put_value(key, value))
+    parse_char(next_grapheme(rest), :garbage, map |> put_value(key, value))
   end
 
-  @spec parse_char({String.t, String.t}, :ivalue, String.t, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({char, rest}, :ivalue, key, value, list) do
-    parse_char(next_grapheme(rest), :ivalue, key, value <> char, list)
+  @spec parse_char({String.t, String.t}, :ivalue, String.t, String.t, map) :: map
+  defp parse_char({char, rest}, :ivalue, key, value, map) do
+    parse_char(next_grapheme(rest), :ivalue, key, value <> char, map)
   end
 
-  @spec parse_char(nil, :ivalue, String.t, String.t, Keyword.t) :: Keyword.t
-  defp parse_char(nil, :ivalue, key, value, list) do
-    list |> put_value(key, value)
+  @spec parse_char(nil, :ivalue, String.t, String.t, map) :: map
+  defp parse_char(nil, :ivalue, key, value, map) do
+    map |> put_value(key, value)
   end
 
-  @spec parse_char({String.t, String.t}, :qvalue, false, String.t, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({"\\", rest}, :qvalue, false, key, value, list) do
-    parse_char(next_grapheme(rest), :qvalue, true, key, value, list)
+  @spec parse_char({String.t, String.t}, :qvalue, false, String.t, String.t, map) :: map
+  defp parse_char({"\\", rest}, :qvalue, false, key, value, map) do
+    parse_char(next_grapheme(rest), :qvalue, true, key, value, map)
   end
 
-  @spec parse_char({String.t, String.t}, :qvalue, true, String.t, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({char, rest}, :qvalue, true, key, value, list) do
-    parse_char(next_grapheme(rest), :qvalue, false, key, value <> char, list)
+  @spec parse_char({String.t, String.t}, :qvalue, true, String.t, String.t, map) :: map
+  defp parse_char({char, rest}, :qvalue, true, key, value, map) do
+    parse_char(next_grapheme(rest), :qvalue, false, key, value <> char, map)
   end
 
-  @spec parse_char({String.t, String.t}, :qvalue, false, String.t, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({"\"", rest}, :qvalue, false, key, value, list) do
-    parse_char(next_grapheme(rest), :garbage, list |> put_value(key, value))
+  @spec parse_char({String.t, String.t}, :qvalue, false, String.t, String.t, map) :: map
+  defp parse_char({"\"", rest}, :qvalue, false, key, value, map) do
+    parse_char(next_grapheme(rest), :garbage, map |> put_value(key, value))
   end
 
-  @spec parse_char({String.t, String.t}, :qvalue, false, String.t, String.t, Keyword.t) :: Keyword.t
-  defp parse_char({char, rest}, :qvalue, false, key, value, list) do
-    parse_char(next_grapheme(rest), :qvalue, false, key, value <> char, list)
+  @spec parse_char({String.t, String.t}, :qvalue, false, String.t, String.t, map) :: map
+  defp parse_char({char, rest}, :qvalue, false, key, value, map) do
+    parse_char(next_grapheme(rest), :qvalue, false, key, value <> char, map)
   end
 
-  @spec parse_char(nil, :qvalue, false, String.t, String.t, Keyword.t) :: Keyword.t
-  defp parse_char(nil, :qvalue, false, key, value, list) do
-    list |> put_value(key, value)
+  @spec parse_char(nil, :qvalue, false, String.t, String.t, map) :: map
+  defp parse_char(nil, :qvalue, false, key, value, map) do
+    map |> put_value(key, value)
   end
 
-  @spec put_value(Keyword.t, String.t, boolean) :: Keyword.t
-  defp put_value(list, key, value) when is_boolean(value) do
-    list ++ Keyword.new([{key |> String.to_atom, value}])
+  @spec put_value(map, String.t, boolean) :: map
+  defp put_value(map, key, value) when is_boolean(value) do
+    map |> Map.put(key, value)
   end
 
-  @spec put_value(Keyword.t, String.t, String.t) :: Keyword.t
-  defp put_value(list, key, value) do
-    list ++ Keyword.new([{key |> String.to_atom, value |> cast}])
+  @spec put_value(map, String.t, String.t) :: map
+  defp put_value(map, key, value) do
+    map |> Map.put(key, value |> coerce_value)
   end
 
-  @spec cast(String.t) :: true
-  defp cast("true"), do: true
+  @spec coerce_value(String.t) :: true
+  defp coerce_value("true"), do: true
 
-  @spec cast(String.t) :: false
-  defp cast("false"), do: false
+  @spec coerce_value(String.t) :: false
+  defp coerce_value("false"), do: false
 
-  @spec cast(String.t) :: number | String.t
-  defp cast(value)  do
+  @spec coerce_value(String.t) :: number | String.t
+  defp coerce_value(value)  do
     integer = case Integer.parse(value) do
       {integer, ""} -> integer
       {_, _}        -> nil

--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -1,15 +1,15 @@
 defmodule Logfmt.Encoder do
-  @spec encode(Keyword.t) :: String.t
+  @spec encode(Dict.t) :: String.t
   def encode(list) do
     Enum.reduce list, "", &encode_pair/2
   end
 
-  @spec encode_pair({Keyword.key, String.t | boolean | number}, String.t) :: String.t
+  @spec encode_pair({Dict.key, String.t | boolean | number}, String.t) :: String.t
   defp encode_pair({key, value}, "") do
     "#{key}=#{value |> encode_value}"
   end
 
-  @spec encode_pair({Keyword.key, String.t | boolean | number}, String.t) :: String.t
+  @spec encode_pair({Dict.key, String.t | boolean | number}, String.t) :: String.t
   defp encode_pair({key, value}, line) do
     "#{line} #{key}=#{value |> encode_value}"
   end

--- a/lib/logfmt.ex
+++ b/lib/logfmt.ex
@@ -22,17 +22,20 @@ defmodule Logfmt do
   end
 
   @doc ~S"""
-  Encodes the given keyword list into a Logfmt-style line
+  Encodes the given Dict into a Logfmt-style line
 
   ## Examples
 
       iex> Logfmt.encode [foo: "bar"]
       "foo=bar"
 
+      iex> Logfmt.encode %{"foo" => "bar"}
+      "foo=bar"
+
       iex> Logfmt.encode [foo: "bar baz"]
       "foo=\"bar baz\""
   """
-  @spec encode(Keyword.t) :: String.t
+  @spec encode(Dict.t) :: String.t
   def encode(list) do
     Logfmt.Encoder.encode(list)
   end

--- a/lib/logfmt.ex
+++ b/lib/logfmt.ex
@@ -1,22 +1,22 @@
 defmodule Logfmt do
   @doc ~S"""
-  Decodes the given line into a keyword list
+  Decodes the given line into a map
 
   ## Examples
 
       iex> Logfmt.decode "foo=bar baz=qux"
-      [foo: "bar", baz: "qux"]
+      %{"foo" => "bar", "baz" => "qux"}
 
       iex> Logfmt.decode ~s(foo="bar baz")
-      [foo: "bar baz"]
+      %{"foo" => "bar baz"}
 
       iex> Logfmt.decode "foo=true"
-      [foo: true]
+      %{"foo" => true}
 
       iex> Logfmt.decode "foo=1"
-      [foo: 1]
+      %{"foo" => 1}
   """
-  @spec decode(String.t) :: Keyword.t
+  @spec decode(String.t) :: map
   def decode(string) do
     Logfmt.Decoder.decode(string)
   end

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -3,82 +3,82 @@ defmodule LogfmtDecodeTest do
   import Logfmt, only: [decode: 1]
 
   test "decodes the empty string" do
-    assert decode("") == []
+    assert decode("") == %{}
   end
 
   test "decodes whitespace-only string" do
-    assert decode("\t") == []
+    assert decode("\t") == %{}
   end
 
   test "decodes keys followed by garbage" do
-    assert decode(~s(key")) == [key: true]
+    assert decode(~s(key")) == %{"key" => true}
   end
 
   test "decodes equals followed by garbage" do
-    assert decode(~s(key==)) == [key: true]
+    assert decode(~s(key==)) == %{"key" => true}
   end
 
   test "decodes unclosed quoted values" do
-    assert decode(~s(foo="bar)) == [foo: "bar"]
+    assert decode(~s(foo="bar)) == %{"foo" => "bar"}
   end
 
   test "decodes a single key/value pair" do
-    assert decode("foo=bar") == [foo: "bar"]
+    assert decode("foo=bar") == %{"foo" => "bar"}
   end
 
   test "decodes multiple key-value pairs" do
-    assert decode("foo=bar baz=qux") == [foo: "bar", baz: "qux"]
+    assert decode("foo=bar baz=qux") == %{"foo" => "bar", "baz" => "qux"}
   end
 
   test "decodes quoted values" do
-    assert decode(~s(foo="bar")) == [foo: "bar"]
+    assert decode(~s(foo="bar")) == %{"foo" => "bar"}
   end
 
   test "decodes standalone keys" do
-    assert decode("foo=bar baz") == [foo: "bar", baz: true]
+    assert decode("foo=bar baz") == %{"foo" => "bar", "baz" => true}
   end
 
   test "decodes standalone keys with equals signs" do
-    assert decode("foo=bar baz=") == [foo: "bar", baz: true]
+    assert decode("foo=bar baz=") == %{"foo" => "bar", "baz" => true}
   end
 
   test "decodes empty qutoed strings" do
-    assert decode(~s(foo="")) == [foo: ""]
+    assert decode(~s(foo="")) == %{"foo" => ""}
   end
 
   test "decodes escaped quotes" do
-    assert decode(~S(foo="escaped \" quote")) == [foo: ~s(escaped " quote)]
+    assert decode(~S(foo="escaped \" quote")) == %{"foo" => ~s(escaped " quote)}
   end
 
   test "decodes \"true\" as a boolean" do
-    assert decode("foo=true") == [foo: true]
+    assert decode("foo=true") == %{"foo" => true}
   end
 
   test "decodes \"false\" as a boolean" do
-    assert decode("foo=false") == [foo: false]
+    assert decode("foo=false") == %{"foo" => false}
   end
 
   test "decodes zero" do
-    assert decode("foo=0") == [foo: 0]
+    assert decode("foo=0") == %{"foo" => 0}
   end
 
   test "decodes positive integers" do
-    assert decode("foo=1") == [foo: 1]
+    assert decode("foo=1") == %{"foo" => 1}
   end
 
   test "decodes negative integers" do
-    assert decode("foo=-1") == [foo: -1]
+    assert decode("foo=-1") == %{"foo" => -1}
   end
 
   test "decodes positive floats" do
-    assert decode("foo=1.2") == [foo: 1.2]
+    assert decode("foo=1.2") == %{"foo" => 1.2}
   end
 
   test "decodes negative floats" do
-    assert decode("foo=-1.2") == [foo: -1.2]
+    assert decode("foo=-1.2") == %{"foo" => -1.2}
   end
 
   test "decodes exponential floats" do
-    assert decode("foo=1.2e9") == [foo: 1.2e9]
+    assert decode("foo=1.2e9") == %{"foo" => 1.2e9}
   end
 end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -6,6 +6,10 @@ defmodule LogfmtEncodeTest do
     assert encode([foo: "bar"]) == "foo=bar"
   end
 
+  test "encodes a map" do
+    assert encode(%{foo: "bar"}) == "foo=bar"
+  end
+
   test "encodes multiple pairs" do
     assert encode([foo: "bar", baz: "qux"]) == "foo=bar baz=qux"
   end


### PR DESCRIPTION
Decoding to Keywords involved converting user data to atoms, which are
not garbage collected.
- [x] Decode log lines to Maps
- [x] Encode any Dict implementation value (round trip testing)
