### PR TITLE
Fixes a few small build warnings in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,11 +10,11 @@ defmodule Logfmt.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      source_url: "https://github.com/jclem/logfmt-elixir",
-     deps: deps,
+     deps: deps(),
 
      # Hex
-     description: description,
-     package: package
+     description: description(),
+     package: package()
      ]
   end
 


### PR DESCRIPTION
Just fixes these (which crop up when I compile my own project that uses this library):
```
warning: variable "deps" does not exist and is being expanded to "deps()", please use
parentheses to remove the ambiguity or change the variable name
  .../deps/logfmt/mix.exs:13

warning: variable "description" does not exist and is being expanded to "description()",
please use parentheses to remove the ambiguity or change the variable name
  .../deps/logfmt/mix.exs:16

warning: variable "package" does not exist and is being expanded to "package()", please
use parentheses to remove the ambiguity or change the variable name
  .../deps/logfmt/mix.exs:17
```