### PR TITLE
Encoder: escape " and other unprintable chars (e.g \n)

### DIFF
--- a/lib/logfmt/encoder.ex
+++ b/lib/logfmt/encoder.ex
@@ -31,7 +31,10 @@ defmodule Logfmt.Encoder do
 
   @spec encode_value(value :: term) :: String.t()
   defp encode_value(value) do
-    str = Logfmt.ValueEncoder.encode(value)
+    str =
+      value
+      |> Logfmt.ValueEncoder.encode()
+      |> escape()
 
     if String.match?(str, ~r/\s/) or String.contains?(str, "=") do
       ["\"", str, "\""]
@@ -45,4 +48,135 @@ defmodule Logfmt.Encoder do
     # with a user configurable option, but for now we'll keep the space.
     [encode_value(key), "=", encode_value(value)]
   end
+
+  defp needs_escaping?(<<>>),
+    do: false
+
+  defp needs_escaping?(<<c, _rest::binary>>) when c <= 0x1F,
+    do: true
+
+  defp needs_escaping?(<<"\"", _rest::binary>>),
+    do: true
+
+  defp needs_escaping?(<<"\\", _rest::binary>>),
+    do: true
+
+  defp needs_escaping?(<<_c, rest::binary>>),
+    do: needs_escaping?(rest)
+
+  defp escape(string) do
+    if needs_escaping?(string) do
+      escape(string, "")
+    else
+      string
+    end
+  end
+
+  defp escape("", acc),
+    do: acc
+
+  defp escape(<<0x0, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0000">>)
+
+  defp escape(<<0x1, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0001">>)
+
+  defp escape(<<0x2, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0002">>)
+
+  defp escape(<<0x3, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0003">>)
+
+  defp escape(<<0x4, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0004">>)
+
+  defp escape(<<0x5, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0005">>)
+
+  defp escape(<<0x6, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0006">>)
+
+  defp escape(<<0x7, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0007">>)
+
+  defp escape(<<0x8, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0008">>)
+
+  defp escape(<<"\t", rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\t">>)
+
+  defp escape(<<"\n", rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\n">>)
+
+  defp escape(<<0xB, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u000b">>)
+
+  defp escape(<<0xC, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u000c">>)
+
+  defp escape(<<"\r", rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\r">>)
+
+  defp escape(<<0xE, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u000e">>)
+
+  defp escape(<<0xF, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u000f">>)
+
+  defp escape(<<0x10, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0010">>)
+
+  defp escape(<<0x11, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0011">>)
+
+  defp escape(<<0x12, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0012">>)
+
+  defp escape(<<0x13, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0013">>)
+
+  defp escape(<<0x14, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0014">>)
+
+  defp escape(<<0x15, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0015">>)
+
+  defp escape(<<0x16, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0016">>)
+
+  defp escape(<<0x17, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0017">>)
+
+  defp escape(<<0x18, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0018">>)
+
+  defp escape(<<0x19, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u0019">>)
+
+  defp escape(<<0x1A, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u001a">>)
+
+  defp escape(<<0x1B, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u001b">>)
+
+  defp escape(<<0x1C, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u001c">>)
+
+  defp escape(<<0x1D, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u001d">>)
+
+  defp escape(<<0x1E, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u001e">>)
+
+  defp escape(<<0x1F, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\u001f">>)
+
+  defp escape(<<"\"", rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\\"">>)
+
+  defp escape(<<"\\", rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, "\\\\">>)
+
+  defp escape(<<c, rest::binary>>, acc),
+    do: escape(rest, <<acc::binary, c>>)
 end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -31,6 +31,18 @@ defmodule LogfmtEncodeTest do
     assert encode(foo: ~s{a b\nc d\ne f\n}) == ~s(foo="a b\\nc d\\ne f\\n")
   end
 
+  test "value with \\ but no spaces does not require quotes" do
+    assert encode(foo: "t3st1\\t3st2") == "foo=t3st1\\t3st2"
+  end
+
+  test ~s{value with " but no spaces requires quotes and escapes anyway} do
+    assert encode(foo: ~s{t3st1"t3st2}) == ~s{foo="t3st1\\"t3st2"}
+  end
+
+  test ~s{value with control character but no spaces requires quotes and escapes anyway} do
+    assert encode(foo: ~s{t3st1\nt3st2}) == ~s{foo="t3st1\\nt3st2"}
+  end
+
   test "encodes a boolean" do
     assert encode(foo: true) == "foo=true"
   end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -23,6 +23,14 @@ defmodule LogfmtEncodeTest do
     assert encode(foo: "bar=baz") == ~s(foo="bar=baz")
   end
 
+  test ~s{escape a value with "} do
+    assert encode(foo: ~s{hello "world"}) == ~s(foo="hello \\"world\\"")
+  end
+
+  test "escape a value with a new line" do
+    assert encode(foo: ~s{a b\nc d\ne f\n}) == ~s(foo="a b\\nc d\\ne f\\n")
+  end
+
   test "encodes a boolean" do
     assert encode(foo: true) == "foo=true"
   end


### PR DESCRIPTION
Escape ", \ and any other control character in the [0-0x1F] unicode
range, using JSON string encoding rules.
Unprintable chars such as '\0' will be encoded as '\u0000'.