### PR TITLE
empty string should be encoded to a="" not a=

### DIFF
--- a/lib/logfmt/encoder.ex
+++ b/lib/logfmt/encoder.ex
@@ -30,6 +30,11 @@ defmodule Logfmt.Encoder do
   end
 
   @spec encode_value(value :: term) :: String.t()
+  defp encode_value(value)
+
+  defp encode_value(""),
+    do: ~s("")
+
   defp encode_value(value) do
     str = Logfmt.ValueEncoder.encode(value)
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -19,6 +19,10 @@ defmodule LogfmtEncodeTest do
     assert encode(foo: "bar baz") == ~s(foo="bar baz")
   end
 
+  test "encode an empty string" do
+    assert encode(empty: "") == ~s(empty="")
+  end
+
   test "quotes a value with =" do
     assert encode(foo: "bar=baz") == ~s(foo="bar=baz")
   end


### PR DESCRIPTION
Make sure that ill-formed outputs such as `foo=` are not produced.