### PR TITLE
Misc doc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 logfmt-*.tar
 
-# Temporary files, for example, from tests.
-/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 logfmt-*.tar
 
+# Temporary files, for example, from tests.
+/tmp/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The MIT License (MIT)
+# The MIT License (MIT)
 
 Copyright (c) 2015 Jonathan Clem
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,28 @@
-# Logfmt [![Build Status](https://github.com/jclem/logfmt-elixir/workflows/CI/badge.svg)](https://github.com/jclem/logfmt-elixir/actions?workflow=CI)
+# Logfmt
+
+[![Build Status](https://github.com/jclem/logfmt-elixir/workflows/CI/badge.svg)](https://github.com/jclem/logfmt-elixir/actions?workflow=CI)
+[![Module Version](https://img.shields.io/hexpm/v/logfmt.svg)](https://hex.pm/packages/logfmt)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/logfmt/)
+[![Total Download](https://img.shields.io/hexpm/dt/logfmt.svg)](https://hex.pm/packages/logfmt)
+[![License](https://img.shields.io/hexpm/l/logfmt.svg)](https://github.com/jclem/logfmt-elixir/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/jclem/logfmt-elixir.svg)](https://github.com/jclem/logfmt-elixir/commits/master)
+
+Logfmt is a module for encoding and decoding logfmt-style log lines.
+
+## Installation
+
+The package can be installed by adding `:logfmt` to your list of dependencies in
+`mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:logfmt, "~> 3.2.0"}
+  ]
+end
+```
+
+## Usages
 
 Decode log lines into maps:
 
@@ -17,7 +41,7 @@ iex> Logfmt.encode %{foo: "bar"}
 "foo=bar"
 ```
 
-Custom types can encoded by implementing the ValueEncoder procotol for it.
+Custom types can encoded by implementing the ValueEncoder protocol for it.
 
 For example to encode DateTime and NaiveDateTime and implementation could look like this:
 
@@ -73,3 +97,10 @@ Now, this module decodes into maps only (with string keys) and encodes any Dict
 implementation type. This is a fair compromise, because ordering upon decoding a
 Logfmt line is not important, and keeping only the last value for a duplicate
 key in a log line is fair, as well.
+
+## Copyright and License
+
+Copyright (c) 2015 Jonathan Clem
+
+This library is released under the MIT License. See the [LICENSE.md](./LICENSE.md) file
+for further details.

--- a/README.md
+++ b/README.md
@@ -97,10 +97,3 @@ Now, this module decodes into maps only (with string keys) and encodes any Dict
 implementation type. This is a fair compromise, because ordering upon decoding a
 Logfmt line is not important, and keeping only the last value for a duplicate
 key in a log line is fair, as well.
-
-## Copyright and License
-
-Copyright (c) 2015 Jonathan Clem
-
-This library is released under the MIT License. See the [LICENSE.md](./LICENSE.md) file
-for further details.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The package can be installed by adding `:logfmt` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:logfmt, "~> 3.2.0"}
+    {:logfmt, "~> 3.3"}
   ]
 end
 ```

--- a/lib/logfmt.ex
+++ b/lib/logfmt.ex
@@ -1,6 +1,6 @@
 defmodule Logfmt do
   @moduledoc """
-  Decodes and encodes logfmt-style log lines
+  Decodes and encodes logfmt-style log lines.
 
   In [logfmt][logfmt]-style log lines, data is encoded as a string of
   `"key-value"` pairs. Logfmt can encode a `Dict` into a string in this format,
@@ -13,7 +13,7 @@ defmodule Logfmt do
   """
 
   @doc ~S"""
-  Decodes the given line into a map
+  Decodes the given line into a map.
 
   ## Examples
 
@@ -28,6 +28,7 @@ defmodule Logfmt do
 
       iex> Logfmt.decode "foo=1"
       %{"foo" => 1}
+
   """
   @spec decode(String.t()) :: map
   def decode(string) do
@@ -35,13 +36,14 @@ defmodule Logfmt do
   end
 
   @doc ~S"""
-  Encodes the given Dict into a Logfmt-style line
+  Encodes the given Dict into a Logfmt-style line.
 
-  Optionally a list of options can be given to change the encode behaviour
+  Optionally a list of options can be given to change the encode behaviour.
 
-  Options:
-  * `output` - if set to :iolist, an iolist is returned,
-               any other value will return a binary
+  ## Options
+
+    * `output` - if set to `:iolist`, an iolist is returned, any other value
+      will return a binary
 
   ## Examples
 
@@ -56,6 +58,7 @@ defmodule Logfmt do
 
       iex> Logfmt.encode [foo: "bar baz"], [output: :iolist]
       [["foo", "=", ["\"", "bar baz", "\""]]]
+
   """
   @spec encode(Dict.t(), options :: Keyword.t()) :: String.t()
   def encode(list, options \\ []) do

--- a/lib/logfmt/decoder.ex
+++ b/lib/logfmt/decoder.ex
@@ -9,6 +9,7 @@ defmodule Logfmt.Decoder do
 
       iex> Logfmt.decode "foo=true"
       %{"foo" => true}
+
   """
   import String, only: [next_grapheme: 1]
 

--- a/lib/logfmt/encoder.ex
+++ b/lib/logfmt/encoder.ex
@@ -9,6 +9,7 @@ defmodule Logfmt.Encoder do
 
       iex> Logfmt.encode [foo: "bar baz", qux: true]
       "foo=\"bar baz\" qux=true"
+
   """
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule Logfmt.MixProject do
       # Hex
       description: description(),
       package: package(),
+      source_url: @source_url,
       docs: docs()
     ]
   end
@@ -42,7 +43,6 @@ defmodule Logfmt.MixProject do
   defp package do
     [
       contributors: ["Jonathan Clem <jotclem@gmail.com>"],
-      licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
       maintainers: ["Jonathan Clem <jonathan@jclem.net>"],
       files: ~w(mix.exs lib README.md LICENSE.md)
@@ -53,7 +53,6 @@ defmodule Logfmt.MixProject do
     [
       extras: ["LICENSE.md": [title: "License"], "README.md": [title: "Readme"]],
       main: "readme",
-      source_url: @source_url,
       source_ref: "v#{@version}",
       formatters: ["html"]
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,8 +1,8 @@
 defmodule Logfmt.MixProject do
   use Mix.Project
 
-  @version "3.3.2"
   @source_url "https://github.com/jclem/logfmt-elixir"
+  @version "3.3.2"
 
   def project do
     [
@@ -13,9 +13,7 @@ defmodule Logfmt.MixProject do
       deps: deps(),
 
       # Hex
-      description: description(),
       package: package(),
-      source_url: @source_url,
       docs: docs()
     ]
   end
@@ -34,14 +32,9 @@ defmodule Logfmt.MixProject do
     ]
   end
 
-  defp description do
-    """
-    Logfmt is a module for encoding and decoding logfmt-style log lines.
-    """
-  end
-
   defp package do
     [
+      description: "Logfmt is a module for encoding and decoding logfmt-style log lines.",
       contributors: ["Jonathan Clem <jotclem@gmail.com>"],
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
@@ -52,9 +45,11 @@ defmodule Logfmt.MixProject do
 
   defp docs do
     [
-      source_ref: "v#{@version}",
+      extras: ["LICENSE.md": [title: "License"], "README.md": [title: "Readme"]],
       main: "readme",
-      extras: ["README.md": [title: "Readme"], "LICENSE.md": [title: "License"]]
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -42,10 +42,8 @@ defmodule Logfmt.MixProject do
 
   defp package do
     [
-      contributors: ["Jonathan Clem <jotclem@gmail.com>"],
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
-      maintainers: ["Jonathan Clem <jonathan@jclem.net>"],
       files: ~w(mix.exs lib README.md LICENSE.md)
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule Logfmt.MixProject do
       deps: deps(),
 
       # Hex
+      description: description(),
       package: package(),
       docs: docs()
     ]
@@ -32,9 +33,14 @@ defmodule Logfmt.MixProject do
     ]
   end
 
+  defp description do
+    """
+    Logfmt is a module for encoding and decoding logfmt-style log lines.
+    """
+  end
+
   defp package do
     [
-      description: "Logfmt is a module for encoding and decoding logfmt-style log lines.",
       contributors: ["Jonathan Clem <jotclem@gmail.com>"],
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},

--- a/mix.exs
+++ b/mix.exs
@@ -54,8 +54,7 @@ defmodule Logfmt.MixProject do
     [
       extras: ["LICENSE.md": [title: "License"], "README.md": [title: "Readme"]],
       main: "readme",
-      source_ref: "v#{@version}",
-      formatters: ["html"]
+      source_ref: "v#{@version}"
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,7 @@ defmodule Logfmt.MixProject do
   defp package do
     [
       contributors: ["Jonathan Clem <jotclem@gmail.com>"],
+      licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
       maintainers: ["Jonathan Clem <jonathan@jclem.net>"],
       files: ~w(mix.exs lib README.md LICENSE.md)


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.